### PR TITLE
Force light mode on Web view

### DIFF
--- a/QueueITLib/QueueITWKViewController.m
+++ b/QueueITLib/QueueITWKViewController.m
@@ -57,6 +57,10 @@ static NSString * const JAVASCRIPT_GET_BODY_CLASSES = @"document.getElementsByTa
                                                                  self.view.bounds.size.height - navigationBarOffset) configuration:config];
     view.navigationDelegate = self;
     self.webView = view;
+
+    if (@available(iOS 13.0, *)) {
+        self.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated{


### PR DESCRIPTION
This PR forces the light mode in the Queue IT Web view. This would avoid such scenarios when in dark mode: 
<img src="https://user-images.githubusercontent.com/23049714/218459401-a0fccdf4-80f5-4b90-aa45-68b3c2347031.png" width=300/>